### PR TITLE
Annotate curry calls as #__PURE__

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,10 @@
           "modules" : false
         }]
       ],
-      "plugins": ["external-helpers"]
+      "plugins": [
+        "external-helpers",
+        "annotate-pure-calls"
+      ]
     },
     "test": {
       "presets": [

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/rambdax.cjs.js",
   "module": "./dist/rambdax.esm.js",
   "typings": "./index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "dev": "jest --watch",
     "devx": "jest --watch __tests__/mapAsync",
@@ -47,6 +48,7 @@
     "rollup-plugin-node-resolve"
   ],
   "devDependencies": {
+    "babel-plugin-annotate-pure-calls": "^0.2.2",
     "babel-plugin-external-helpers": "^7.0.0-beta.3",
     "babel-preset-env": "^1.6.1",
     "commit-message": "https://github.com/selfrefactor/commit-message#3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -395,6 +395,12 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-annotate-pure-calls@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.2.2.tgz#a0d8c27361db4a518d925a7202f8854382b17594"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
@@ -421,6 +427,10 @@ babel-plugin-jest-hoist@^23.0.0-alpha.4:
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
 
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
@@ -3160,9 +3170,9 @@ rambda@^1.0.9, rambda@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/rambda/-/rambda-1.1.0.tgz#f184f22acead64287c74c9de94853fb4cc32b852"
 
-"rambda@git+https://github.com/selfrefactor/rambda.git#1.1.0":
+"rambda@https://github.com/selfrefactor/rambda#1.1.0":
   version "1.0.9"
-  resolved "git+https://github.com/selfrefactor/rambda.git#ee04b4005da84b29d166364100d50e2a9be56a60"
+  resolved "https://github.com/selfrefactor/rambda#ee04b4005da84b29d166364100d50e2a9be56a60"
 
 rambdax@^0.8.10, rambdax@^0.8.8:
   version "0.8.10"


### PR DESCRIPTION
related https://github.com/selfrefactor/rambda/pull/67

this makes `assocPath`, `evolve` & internal `NO_MATCH_FOUND` tree-shakeable