### PR TITLE
fix: error TS2314: Generic type 'MapInterface<T>'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -630,7 +630,7 @@ add(a: number, b: number): number
 
     length<T>(list: T[]): number
 
-    map<In, Out>(fn: MapFunction<In, Out>): MapInterface<In, Out>
+    map<In, Out>(fn: MapFunction<In, Out>): MapInterface<Out>
     map<In, Out>(fn: MapFunction<In, Out>, list: In[]): Out[]
 
     map<In, Out>(


### PR DESCRIPTION
Fixing typings error:

```powershell
PS C:\_GITHUB\rambdax> npx typescript .\index.d.ts
npx: installed 1 in 3.636s
index.d.ts:633:45 - error TS2314: Generic type 'MapInterface<T>' requires 1 type argument(s).

633     map<In, Out>(fn: MapFunction<In, Out>): MapInterface<In, Out>
                                                ~~~~~~~~~~~~~~~~~~~~~


Found 1 error.
```