### PR TITLE
explicitly define isValid type def

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1690,7 +1690,7 @@ export function isType(targetType: RambdaTypes): (input: any) => boolean;
  * 
  * Please [check the detailed explanation](https://github.com/selfrefactor/rambdax/blob/master/files/isValid.md) as it is hard to write a short description for this method.
  */
-export function isValid({input: object, schema: Schema}): boolean;
+export function isValid({input: object, schema: Schema}: IsValid): boolean;
 
 /**
  * Asynchronous version of `R.isValid`


### PR DESCRIPTION
tiny fix to define isValid explicitly

aka fixes the error given by VSCode w/ Typescript 4.1.3
![image](https://user-images.githubusercontent.com/2984350/104383090-3ce48380-54fd-11eb-9a3a-fb75a9df1889.png)
